### PR TITLE
Replace time with std::time. Slight API change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ name = "hertz"
 readme = "README.md"
 repository = "https://github.com/snd/hertz.git"
 version = "0.2.0"
-
-[dependencies]
-time = "0.1.34"


### PR DESCRIPTION
u64 for instants are changed to std::time::Instant
current_time_ns is removed, users should use Instant::new
sleep_for_constant_rate is modified to Instant
